### PR TITLE
get_key_value did not return values

### DIFF
--- a/login.php
+++ b/login.php
@@ -53,9 +53,10 @@ function decrypt_string($base64, $key) {
  * querystring helper, returns the value of a key in a string formatted in key=value&key=value&key=value pairs, e.g. saved querystrings
  */
 function get_key_value($string, $key) {
-    $list = explode( '&', $string);
+    $list = explode( '&', str_replace( '&amp;', '&', $string));
     foreach ($list as $pair) {
     	$item = explode( '=', $pair);
+    	// actxc echo "item: ".$key."/".$item[0]."/".$item[1]." <br>";
 		if (strtolower($key) == strtolower($item[0])) {
 			return urldecode($item[1]); // not for use in $_GET etc, which is already decoded, however our encoder uses http_build_query() before encrypting
 		}


### PR DESCRIPTION
When I tried to log in, nothing happend.
I found that get_key_value()  did not return values.
I found a problem with ampersand and explode, that I did not understand well, 
but I found examples ( https://www.google.de/search?q=php+explode+ampersand )
and tried a simple change that worked. I can not see a situation, where the content of $item[0] needs to be ';amp&', so the patch might be good for everyone?

My WP  4.1.1–de_DE  and moodle Moodle 2.8.5+ (Build: 20150402)  are running on  the same server.

Distributor ID: Debian
Description:    Debian GNU/Linux 6.0.10 (squeeze)
Release:        6.0.10
Codename:       squeeze

PHP 5.4.39