### PR TITLE
Change constructor function name from the class name to __construct()…

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -27,7 +27,7 @@ class auth_plugin_wp2moodle extends auth_plugin_base {
     /**
      * Constructor.
      */
-    function auth_plugin_wp2moodle() {
+    function __construct() {
         $this->authtype = 'wp2moodle';
         $this->config = get_config('auth/wp2moodle');
     }


### PR DESCRIPTION
… inline with PHP7 conventions.

Fixes #31 